### PR TITLE
Fixed an error with multiple pages

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -94,19 +94,27 @@ function call(url, method, body, mime) {
         body = JSON.stringify(body)
         mime = 'application/json'
     }
-    return lazyToken()
-        .then(token => RP({
-            baseUrl: 'https://api.onedrive.com/v1.0/',
+
+    var options = {
             uri: url,
             body: body,
             method: method,
             headers: {
-                Authorization: 'bearer '+token,
                 'Content-Type': mime || 'application/octet-stream',
                 'Content-Encoding': contentEncoding,
                 Prefer: prefer
             }
-        }) )
+    };
+
+    if (!url.startsWith('https://api.onedrive.com')) {
+      options.baseUrl = 'https://api.onedrive.com/v1.0/'
+    }
+
+    return lazyToken()
+        .then(token => {
+                options.headers.Authorization = 'bearer '+token;
+		return RP(options)
+         })
         .then(data => {
             return data === '' ? null : JSON.parse(data)
         })

--- a/bin/onedrive
+++ b/bin/onedrive
@@ -112,8 +112,8 @@ function call(url, method, body, mime) {
 
     return lazyToken()
         .then(token => {
-                options.headers.Authorization = 'bearer '+token;
-		return RP(options)
+            options.headers.Authorization = 'bearer ' + token;
+            return RP(options)
          })
         .then(data => {
             return data === '' ? null : JSON.parse(data)


### PR DESCRIPTION
This fixed the error `options.uri must be a path when using options.baseUrl` when using `onedrive ls` on a folder with many files.

The `@odata.nextLink` field in the result of `listPage()` is a absolute url, so the next call to `listPage()` will have this as `cont` param and the `call(cont)` will fail with the error above.

This fix only sets the `baseUrl` option if the `url` parameter does not starts with the api base url `https://api.onedrive.com`
