### PR TITLE
feat: implement rm command for remote file/folder deletion

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -472,11 +472,33 @@ async function cp(args) {
     }
 }
 
-function rm(args) {
+/*
+DELETE /drive/root:/{path}:
+Returns 204 No Content on success.
+Supports files and folders (recursive delete).
+*/
+async function rmItem(remote) {
+    remote = sanitize(remote)
+    const token = await lazyToken()
+    const resp = await fetch(makeAbsolute(remote), {
+        agent: httpsAgent,
+        method: 'DELETE',
+        headers: {
+            Authorization: 'bearer ' + token,
+        },
+    })
+    await checkResponse(resp)
+    // 204 No Content on success — nothing to parse
+}
+
+async function rm(args) {
     if (args.length < 1) {
         console.error('usage: rm file ...')
     } else {
-        throw Error('Remote rm is not implemented')
+        for (const cur of args) {
+            await rmItem(cur)
+            console.log(`removed '${cur}'`)
+        }
     }
 }
 


### PR DESCRIPTION
Replaces the stub that threw `"Remote rm is not implemented"` with a working implementation using `DELETE /drive/root:/{path}:` (OneDrive API — returns 204 No Content on success).

### Changes

- Extracted `rmItem(remote)` function that sends a `DELETE` request via fetch, reusing existing infrastructure: `sanitize()`, `lazyToken()`, `httpsAgent`, `checkResponse()`
- Updated `rm(args)` to iterate over arguments and call `rmItem()` for each, printing confirmation
- Added API doc block comment above `rmItem` matching the style of neighbouring functions (`upload`, `wget`, `createFolder`, etc.)

### Testing — 14 edge cases, all passed

| Scenario | Result |
|----------|--------|
| Simple file | ✅ |
| File in nested subdirectory | ✅ |
| Empty folder | ✅ |
| Folder with contents (recursive delete) | ✅ |
| Non-existent file (404) | ✅ — graceful error |
| Double deletion | ✅ — graceful error |
| Root deletion | ✅ — blocked by API |
| Empty args | ✅ — prints usage |
| Filename with spaces | ✅ |
| Special characters (!@#) | ✅ |
| Dots in filename | ✅ |
| Hidden file (leading dot) | ✅ |
| 100-char filename | ✅ |
| Path without `:/` prefix | ✅ (sanitize handles it) |

### Notes

- **No new dependencies.** Uses only `fetch`, `httpsAgent`, `lazyToken`, `sanitize`, `checkResponse` — all already present in the codebase.
- **No other functions modified.**
- `mv` function is untouched (verified after edit).
- Files >100MiB require range API — out of scope for this change.