### PR TITLE
fix: only claim token delivery when the CLI actually accepted it

### DIFF
--- a/docs/oauthcallbackhandler.html
+++ b/docs/oauthcallbackhandler.html
@@ -527,14 +527,40 @@
                             encodeURIComponent(lb[1]) +
                             '&token=' +
                             encodeURIComponent(access_token)
-                        var delivered = function () {
-                            statusText.textContent =
-                                'Token sent to your terminal — you can close this tab.'
-                        }
-                        fetch(target, { mode: 'cors' }).then(delivered, function () {
-                            // fetch blocked? fire an <img> GET (delivery only).
-                            new Image().src = target
-                        })
+                        // The listener replies 200 only when it accepted the
+                        // token (nonce matched), and its ACAO:* header lets us
+                        // read that status -- so response.ok is a genuine ack,
+                        // not just "something answered on that port".
+                        fetch(target, { mode: 'cors' })
+                            .then(function (resp) {
+                                if (resp.ok) {
+                                    accepted()
+                                }
+                                // Non-2xx: the CLI refused the token (stale or
+                                // tampered state) -- keep the copy fallback.
+                            })
+                            .catch(function () {
+                                // fetch blocked? fire an <img> GET as a last
+                                // resort. Delivery only: an image load gives no
+                                // readable status, so never claim success here.
+                                new Image().src = target
+                            })
+                    }
+
+                    // The CLI confirmed it saved the token: say so and retire
+                    // the manual copy UI, so the page reflects what happened
+                    // instead of instructing a step that's already done.
+                    function accepted() {
+                        statusText.textContent =
+                            'The CLI received the token — you can close this tab.'
+                        document.querySelector('h1').textContent = "You're in."
+                        document.querySelector('.lead').innerHTML =
+                            'The token was delivered to <b>your terminal</b> and saved. No need to copy anything.'
+                        document.querySelector('.term').style.display = 'none'
+                        document.querySelector('.actions').style.display =
+                            'none'
+                        document.querySelector('.hint').textContent =
+                            'You can close this tab and return to your terminal.'
                     }
                 }
 


### PR DESCRIPTION
## What

The OAuth callback page forwards the access token to the CLI's loopback listener and showed "Token sent to your terminal" whenever the fetch *resolved* — but `fetch()` resolves on HTTP errors too, so the success message could appear even when the CLI rejected the token (e.g. a stale or tampered `state` nonce → 400).

Now the page treats `response.ok` as the acknowledgment: the listener replies **200 only when it accepted the token** (nonce matched, token captured) and 400 otherwise, and its existing `Access-Control-Allow-Origin: *` header makes that status readable cross-origin.

On a confirmed acceptance the page also reflects it properly instead of still instructing a manual paste:

- badge: "The CLI received the token — you can close this tab"
- headline: "You're in.", lead updated
- the copy-command terminal box and button are hidden — there's nothing left to paste

On a non-2xx reply or an unreachable listener, the manual copy fallback stays. The `<img>` beacon fallback (for when fetch is blocked) is delivery-only and never claims success, since an image load exposes no readable status.

## Testing

Verified in a browser against a mimic of the CLI's listener with identical response behavior:

- correct nonce → 200 → accepted UI shown, listener logged the token
- wrong nonce → 400 → copy UI stays, no false success claim
- dead port → fetch rejects → copy UI stays, img beacon fired

Prettier clean. Note: GitHub Pages serves `docs/`, so this goes live at `www.lunesu.com/onedrive-cli/oauthcallbackhandler.html` when merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)