### PR TITLE
fix: build a valid permission URL in chmod

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -907,17 +907,12 @@ async function chmod1(mode, remote) {
     let ok // FIXME track result from all shares
     for (const cur of result.value) {
         if (mode === MINUS_RW) {
-            ok = await call(
-                '/drive/root' + remote + ':/permissions/' + cur.id,
-                'DELETE'
-            )
+            ok = await call(remote + '/permissions/' + cur.id, 'DELETE')
         } else if (cur.roles[0] === 'write') {
             // FIXME: generic 'edit' links cannot be patched to be read only
-            ok = await call(
-                '/drive/root' + remote + ':/permissions/' + cur.id,
-                'PATCH',
-                { roles: ['read'] }
-            )
+            ok = await call(remote + '/permissions/' + cur.id, 'PATCH', {
+                roles: ['read'],
+            })
         }
     }
     return ok ? 'OK' : 'Nothing was changed'


### PR DESCRIPTION
## What changed

`chmod1()` in [`bin/onedrive`](bin/onedrive) built a malformed URL for its per-permission `DELETE`/`PATCH`.

`sanitize(remote)` already yields the full address form `/drive/root:/PATH:`, but both mutating calls prepended another `/drive/root` and appended a second colon:

```
/drive/root/drive/root:/PATH::/permissions/{id}
```

— a doubled prefix and a stray extra colon. Both now use the already-sanitized `remote` directly, matching the adjacent (correct) `call(remote + '/permissions')` on the line above.

| request | before | after |
|---|---|---|
| `GET` (unchanged) | `/drive/root:/Docs/my file.txt:/permissions` | same |
| `DELETE` (`-rw`) | `/drive/root/drive/root:/Docs/my file.txt::/permissions/{id}` | `/drive/root:/Docs/my file.txt:/permissions/{id}` |
| `PATCH` (`-w`) | `/drive/root/drive/root:/Docs/my file.txt::/permissions/{id}` | `/drive/root:/Docs/my file.txt:/permissions/{id}` |

## Why

The bogus path meant `chmod -w` and `chmod -rw` could never actually downgrade or remove a share.

## Verification

Exercised the real `chmod1` code path with a stubbed `node-fetch` transport and two permissions (one `write`, one `read`), capturing the URLs the CLI builds. `-w` PATCHes only the `write` permission; `-rw` DELETEs both. The table above is that output, before and after the change.

`npm run lint` and `npx prettier -c bin/onedrive` both pass.

**Not yet verified against a live drive.** The local token is expired, and the CLI deliberately refuses to sign in without a TTY ("Cannot sign in interactively without a terminal (e.g. in CI or when invoked by an agent)"), so the end-to-end `ln` → `chmod -w` → `chmod -rw` → `stat` round-trip still needs a human run after `onedrive login`. Expect `OK` from each chmod rather than `Nothing was changed`, and the `shared` facet to disappear after `-rw`.

One pre-existing caveat, unchanged by this PR: per the existing `FIXME`, a generic *edit* link cannot be PATCHed down to read-only, so `-w` may still fail server-side on such a link. `ln` requests `type: 'view'`, so reaching that needs an edit link created elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)