### PR TITLE
fix: list and traverse folders shared with you (closes #7)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-    "env": {
-        "es2018": true,
-        "node": true
-    },
-    "extends": "eslint:recommended"
-};

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ they live outside the folder hierarchy and only reference the files, so
 Deleting an album itself is not supported by the API — use the OneDrive
 web UI for that.
 
+##### Browse a folder shared with you
+
+```sh
+onedrive ls :/Team                    # the shared folder as it appears on your drive
+onedrive cat :/Team/notes.txt
+onedrive cp -R :/Team ./local-copy
+```
+
+A folder shared with you appears on your drive as a stub pointing at the item
+on the owner's drive, so its contents are addressed on _that_ drive. The CLI
+follows the stub for you: use the shared folder's path as it appears in your
+own OneDrive and `ls`, `find`, `cat`, `cp` and friends work as usual. Use the
+"Add to my OneDrive" button in the web view for anything shared with you that
+does not show up in `ls` yet.
+
 ## MCP server
 
 `onedrive mcp` starts a read-only [Model Context Protocol](https://modelcontextprotocol.io)

--- a/bin/onedrive
+++ b/bin/onedrive
@@ -758,7 +758,7 @@ function openBrowser(url) {
             .spawn(opener, [url], { stdio: 'ignore', detached: true })
             .on('error', () => {})
             .unref()
-    } catch (e) {
+    } catch {
         /* best effort */
     }
 }
@@ -824,7 +824,7 @@ async function login(args) {
     let lb = null
     try {
         lb = await loopbackLogin(readonly)
-    } catch (e) {
+    } catch {
         // Couldn't bind a local port; fall back to the manual paste prompt.
     }
     if (!lb) {
@@ -1570,7 +1570,7 @@ async function mcp() {
             let lb = null
             try {
                 lb = await loopbackLogin(readonly)
-            } catch (e) {
+            } catch {
                 // Couldn't bind a local port; fall through to the paste path.
             }
             const url = lb ? lb.url : buildLoginUrl(readonly)
@@ -1606,7 +1606,7 @@ async function mcp() {
                     await saveToken(captured)
                     lb.cancel()
                     return asJson({ ok: true, message: 'Access token saved.' })
-                } catch (err) {
+                } catch {
                     // Presented, but the token didn't arrive in time.
                     lb.cancel()
                     return asJson({

--- a/bin/onedrive
+++ b/bin/onedrive
@@ -234,6 +234,102 @@ function sanitize(remote) {
     )
 }
 
+// The path components of a remote path, without the ':/' prefix.
+function splitPath(remote) {
+    return remote
+        .replace(/^:?\/?\.?/, '')
+        .split('/')
+        .filter(Boolean)
+}
+
+// The ':/'-prefixed form the CLI accepts as input, used as the prefix when
+// building the paths of a folder's children. The drive root is just ':'.
+function displayPath(remote) {
+    const parts = splitPath(remote)
+    return parts.length ? ':/' + parts.join('/') : ':'
+}
+
+// An item shared with you appears on your drive as a stub carrying a
+// `remoteItem` facet: the stub is a real item (so `stat` works) but the
+// contents live on the owner's drive, which is why listing the stub's own
+// children always comes back empty. The facets that matter -- folder, size,
+// shared, ... -- hang off remoteItem rather than off the stub.
+// See https://github.com/lionello/onedrive-cli/issues/7
+function facets(info) {
+    return info.remoteItem || info
+}
+
+// Address an item by drive + item id, the only way to reach something on
+// another drive. For a shared stub this addresses the target item on the
+// owner's drive, not the stub itself.
+function itemAddress(info) {
+    const target = facets(info)
+    const driveId = target.parentReference && target.parentReference.driveId
+    return driveId
+        ? '/drives/' + driveId + '/items/' + target.id
+        : '/drive/items/' + target.id
+}
+
+// Everything below a shared folder lives on the owner's drive, so its path on
+// our drive doesn't resolve. Walk down from the top: the first ancestor with a
+// remoteItem is the shared stub, and the remainder of the path can be
+// addressed relative to the item it points at. Returns undefined when no stub
+// is involved, i.e. the path is genuinely missing.
+async function resolveShared(remote) {
+    const parts = splitPath(remote)
+    for (let i = 1; i < parts.length; ++i) {
+        let info
+        try {
+            info = await call(sanitize(parts.slice(0, i).join('/')))
+        } catch (err) {
+            if (err.statusCode === 404) {
+                return undefined
+            }
+            throw err
+        }
+        if (info.remoteItem) {
+            return (
+                itemAddress(info) +
+                ':/' +
+                parts.slice(i).map(encodeURIComponent).join('/') +
+                ':'
+            )
+        }
+    }
+    return undefined
+}
+
+// Run a request against a remote path, retrying on the owner's drive when the
+// path turns out to live inside a shared folder. Ordinary paths pay nothing
+// extra: the retry only kicks in after a 404.
+async function withShared(remote, fn) {
+    try {
+        return await fn(sanitize(remote))
+    } catch (err) {
+        if (err.statusCode !== 404) {
+            throw err
+        }
+        const shared = await resolveShared(remote)
+        if (!shared) {
+            throw err
+        }
+        return fn(shared)
+    }
+}
+
+// The address to enumerate a folder's children from. Unlike withShared this
+// always costs a GET of the folder itself, and that is precisely what makes
+// shared folders work: the stub is a valid item, its /children is just empty.
+async function resolveFolder(remote) {
+    if (splitPath(remote).length === 0) {
+        return sanitize(remote) // the drive root is never a shared stub
+    }
+    return withShared(remote, async address => {
+        const info = await call(address)
+        return info.remoteItem ? itemAddress(info) : address
+    })
+}
+
 function absolute(info) {
     const parent = info.parentReference.path.replace(/^\/drive\/root/, '')
     return decodeURIComponent(parent) + '/' + info.name
@@ -274,24 +370,28 @@ async function ls_paged(total, cont) {
     const now = Moment()
     const threshold = 1000 * 60 * 60 * 24 * 180 //180days
     for (const f of result.value) {
-        const m = Moment(f.lastModifiedDateTime)
-        const d = 'folder' in f
+        // Read the metadata through the remoteItem facet, so a folder shared
+        // with us is listed as a folder (with its owner and child count)
+        // instead of as an empty file.
+        const info = facets(f)
+        const m = Moment(info.lastModifiedDateTime || f.lastModifiedDateTime)
+        const d = is_folder(f)
         let mod = d ? 'drwx' : '-rw-'
-        if ('shared' in f) {
+        if ('shared' in info) {
             if (
-                'effectiveRoles' in f.shared &&
-                f.shared.effectiveRoles.length === 1 &&
-                f.shared.effectiveRoles[0] === 'read'
+                'effectiveRoles' in info.shared &&
+                info.shared.effectiveRoles.length === 1 &&
+                info.shared.effectiveRoles[0] === 'read'
             ) {
                 mod += d ? 'r-x' : 'r--'
-                if (f.shared.scope === 'anonymous') {
+                if (info.shared.scope === 'anonymous') {
                     mod += d ? 'r-x' : 'r--'
                 } else {
                     mod += '---'
                 }
             } else {
                 mod += d ? 'rwx' : 'rw-'
-                if (f.shared.scope === 'anonymous') {
+                if (info.shared.scope === 'anonymous') {
                     mod += d ? 'rwx' : 'rw-'
                 } else {
                     mod += '---'
@@ -300,13 +400,14 @@ async function ls_paged(total, cont) {
         } else {
             mod += '------'
         }
-        const count = d ? f.folder.childCount : 1
+        const count = d && info.folder ? info.folder.childCount : 1
         total += count
+        const by = info.createdBy || f.createdBy
         console.log(
             mod,
             padLeft(count, 3),
-            f.createdBy.user.displayName,
-            padLeft(f.size, 10),
+            (by && by.user && by.user.displayName) || '',
+            padLeft(info.size || 0, 10),
             m.format(
                 Math.abs(now - m) < threshold ? 'MMM DD HH:mm' : 'MMM DD  YYYY'
             ),
@@ -324,7 +425,8 @@ async function ls(folders) {
     //console.log(Colors.bold('Permission Cnt Owner            Size     Date         Name'))
     let result = 0
     for (const folder of folders) {
-        result = await ls_paged(result, sanitize(folder) + '/children')
+        const address = await resolveFolder(folder)
+        result = await ls_paged(result, address + '/children')
     }
     return 'total ' + result
 }
@@ -343,26 +445,25 @@ async function upload(op, from, target) {
     if (target.endsWith('/')) {
         target = target + Path.basename(from)
     }
-    target = sanitize(target)
+    const label = sanitize(target)
     const mime = Mime.lookup(from)
     const data = await FS.readFile(from)
     // TODO: skip upload if SHA1 is the same
-    const result = await call(
-        target + '/content?@name.conflictBehavior=fail',
-        'PUT',
-        data,
-        { 'Content-Type': mime }
+    const result = await withShared(target, address =>
+        call(address + '/content?@name.conflictBehavior=fail', 'PUT', data, {
+            'Content-Type': mime,
+        })
     )
     const sha1 = sha1hash(data).toUpperCase()
     if (sha1 !== result.file.hashes.sha1Hash) {
-        throw Error('sha1Hash mismatch: ' + target)
+        throw Error('sha1Hash mismatch: ' + label)
     }
     try {
         if (op === MOVE) {
-            console.log(from, '=>', target, result.id)
+            console.log(from, '=>', label, result.id)
             await FS.unlink(from)
         } else {
-            console.log(from, '->', target, result.id)
+            console.log(from, '->', label, result.id)
         }
     } catch (err) {
         if (err.statusCode === 404) {
@@ -399,9 +500,8 @@ async function wget(args) {
         if (data.name === '' || target.endsWith('/')) {
             throw Error('Invalid target name')
         }
-        let path = Path.dirname(target + 'hack')
+        const path = await resolveFolder(Path.dirname(target + 'hack'))
         target = sanitize(target)
-        path = sanitize(path)
         await call(path + '/children', 'POST', data, {
             Prefer: 'respond-async',
         })
@@ -422,9 +522,10 @@ async function download(op, from, target) {
     if (target.endsWith('/')) {
         target = target + Path.basename(from)
     }
-    const remote = sanitize(from)
     // TODO: avoid download if the SHA1 is the same
-    const data = await getContent(remote + '/content')
+    const data = await withShared(from, address =>
+        getContent(address + '/content')
+    )
     await FS.writeFile(target, data)
     if (op === MOVE) {
         console.log(from, '=>', target)
@@ -446,14 +547,13 @@ Content-type: application/json
 }
 */
 function moveItem(item, path, name) {
-    const remote = sanitize(item)
     const data = {
         name: name,
         parentReference: {
             path: sanitize(path), // FIXME: double escapes
         },
     }
-    return call(remote, 'PATCH', data)
+    return withShared(item, address => call(address, 'PATCH', data))
 }
 
 async function rename(from, target) {
@@ -509,26 +609,36 @@ async function cp_mv(op, args, target) {
     }
 }
 
-async function cp_paged(cont, target) {
+// `prefix` is the remote path of the folder being listed: children of a folder
+// on someone else's drive have a parentReference we cannot address by path, so
+// track the path as we descend instead of deriving it from the item.
+async function cp_paged(cont, target, prefix) {
     if (cont === undefined) {
         return
     }
     const result = await call(cont)
     // TODO: copy by Item ID instead of path?
-    const files = result.value.filter(info => !is_folder(info)).map(absolute)
+    const files = result.value
+        .filter(info => !is_folder(info))
+        .map(info => prefix + '/' + info.name)
     await cp_mv(COPY, files, target + '/')
-    await cp_paged(result['@odata.nextLink'], target)
+    await cp_paged(result['@odata.nextLink'], target, prefix)
     // Recurse into subfolders
     const folders = result.value.filter(is_folder)
     for (const info of folders) {
         const folder = Path.join(target, info.name)
         await FS.mkdir(folder)
-        await cp_paged(sanitize(absolute(info)) + '/children', folder)
+        await cp_paged(
+            itemAddress(info) + '/children',
+            folder,
+            prefix + '/' + info.name
+        )
     }
 }
 
 function is_folder(info) {
-    return info.folder || (info.package && info.package.type === 'oneNote')
+    const f = facets(info)
+    return !!(f.folder || (f.package && f.package.type === 'oneNote'))
 }
 
 async function cp(args) {
@@ -549,7 +659,8 @@ async function cp(args) {
 
         // Recursive copy
         for (const folder of args.slice(1)) {
-            await cp_paged(sanitize(folder) + '/children', target)
+            const address = await resolveFolder(folder)
+            await cp_paged(address + '/children', target, displayPath(folder))
         }
     }
 }
@@ -577,7 +688,7 @@ Returns 204 No Content on success.
 Supports files and folders (recursive delete).
 */
 function rmItem(remote) {
-    return del(sanitize(remote))
+    return withShared(remote, address => del(address))
 }
 
 async function rm(args) {
@@ -616,13 +727,13 @@ Content-Type: application/json
   "file": { }
 }
 */
-function createFolder(parent, name) {
-    const remote = sanitize(parent)
+async function createFolder(parent, name) {
+    const address = await resolveFolder(parent)
     const data = {
         name: name,
         folder: {},
     }
-    return call(remote + '/children', 'POST', data)
+    return call(address + '/children', 'POST', data)
 }
 
 async function mkdir1(dir) {
@@ -643,8 +754,9 @@ async function mkdir(args) {
 }
 
 async function cat1(remote) {
-    remote = sanitize(remote)
-    const data = await getContent(remote + '/content')
+    const data = await withShared(remote, address =>
+        getContent(address + '/content')
+    )
     print(data)
 }
 
@@ -989,8 +1101,7 @@ async function sendmail(args) {
 }
 
 function getItem(file) {
-    const remote = sanitize(file)
-    return call(remote)
+    return withShared(file, address => call(address))
 }
 
 async function stat1(file) {
@@ -1007,15 +1118,17 @@ async function stat(args) {
     }
 }
 
-async function find_paged(cont, expression) {
+// See cp_paged for why the path is tracked in `prefix` instead of read back
+// off each item.
+async function find_paged(cont, expression, prefix) {
     if (cont === undefined) {
         return
     }
     const result = await call(cont)
     result.value
-        .filter(info => expression.dirOnly !== !info.folder)
+        .filter(info => expression.dirOnly !== !is_folder(info))
         .filter(info => !expression.regex || expression.regex.test(info.name))
-        .map(absolute)
+        .map(info => prefix + '/' + info.name)
         .forEach(file => {
             if (expression.print0) {
                 process.stdout.write(file)
@@ -1024,11 +1137,15 @@ async function find_paged(cont, expression) {
                 console.log(file)
             }
         })
-    await find_paged(result['@odata.nextLink'], expression)
+    await find_paged(result['@odata.nextLink'], expression, prefix)
     // Recurse into subfolders
-    const folders = result.value.filter(info => info.folder)
+    const folders = result.value.filter(is_folder)
     for (const info of folders) {
-        await find_paged(sanitize(absolute(info)) + '/children', expression)
+        await find_paged(
+            itemAddress(info) + '/children',
+            expression,
+            prefix + '/' + info.name
+        )
     }
 }
 
@@ -1076,7 +1193,12 @@ async function find(args) {
             }
         }
         for (const folder of args) {
-            await find_paged(sanitize(folder) + '/children', expression)
+            const address = await resolveFolder(folder)
+            await find_paged(
+                address + '/children',
+                expression,
+                displayPath(folder)
+            )
         }
     }
 }
@@ -1256,17 +1378,20 @@ async function album(args) {
 // Structured equivalents of ls/grep/find that return data instead of printing.
 async function listFolder(path) {
     const items = []
-    let cont = sanitize(path) + '/children'
+    const prefix = displayPath(path)
+    let cont = (await resolveFolder(path)) + '/children'
     while (cont) {
         const result = await call(cont)
         for (const f of result.value) {
+            const info = facets(f)
             items.push({
                 name: f.name,
-                path: absolute(f),
+                path: prefix + '/' + f.name,
                 type: is_folder(f) ? 'folder' : 'file',
-                size: f.size,
-                lastModified: f.lastModifiedDateTime,
-                ...(f.folder ? { childCount: f.folder.childCount } : {}),
+                size: info.size,
+                lastModified:
+                    info.lastModifiedDateTime || f.lastModifiedDateTime,
+                ...(info.folder ? { childCount: info.folder.childCount } : {}),
             })
         }
         cont = result['@odata.nextLink']
@@ -1288,22 +1413,36 @@ async function searchContent(query) {
 }
 
 async function findItems(path, expression, acc = []) {
-    let cont = sanitize(path) + '/children'
+    return findItemsAt(
+        await resolveFolder(path),
+        displayPath(path),
+        expression,
+        acc
+    )
+}
+
+async function findItemsAt(address, prefix, expression, acc) {
+    let cont = address + '/children'
     while (cont) {
         const result = await call(cont)
         for (const info of result.value) {
             const matchesType =
                 expression.dirOnly === undefined ||
-                expression.dirOnly === !!info.folder
+                expression.dirOnly === is_folder(info)
             const matchesName =
                 !expression.regex || expression.regex.test(info.name)
             if (matchesType && matchesName) {
-                acc.push(absolute(info))
+                acc.push(prefix + '/' + info.name)
             }
         }
         // Recurse into subfolders found on this page.
-        for (const info of result.value.filter(i => i.folder)) {
-            await findItems(absolute(info), expression, acc)
+        for (const info of result.value.filter(is_folder)) {
+            await findItemsAt(
+                itemAddress(info),
+                prefix + '/' + info.name,
+                expression,
+                acc
+            )
         }
         cont = result['@odata.nextLink']
     }
@@ -1451,10 +1590,8 @@ async function mcp() {
             },
         },
         async ({ path, offset, length }) => {
-            const { buffer, total } = await getRange(
-                sanitize(path) + '/content',
-                offset,
-                length
+            const { buffer, total } = await withShared(path, address =>
+                getRange(address + '/content', offset, length)
             )
             return asJson({
                 path,

--- a/docs/index.html
+++ b/docs/index.html
@@ -532,6 +532,20 @@ they live outside the folder hierarchy and only reference the files, so
 Deleting an album itself is not supported by the API — use the OneDrive
 web UI for that.</p>
 
+<h5>Browse a folder shared with you</h5>
+
+<pre><code class="sh">onedrive ls :/Team                    # the shared folder as it appears on your drive
+onedrive cat :/Team/notes.txt
+onedrive cp -R :/Team ./local-copy
+</code></pre>
+
+<p>A folder shared with you appears on your drive as a stub pointing at the item
+on the owner&#39;s drive, so its contents are addressed on <em>that</em> drive. The CLI
+follows the stub for you: use the shared folder&#39;s path as it appears in your
+own OneDrive and <code>ls</code>, <code>find</code>, <code>cat</code>, <code>cp</code> and friends work as usual. Use the
+&quot;Add to my OneDrive&quot; button in the web view for anything shared with you that
+does not show up in <code>ls</code> yet.</p>
+
 <h2>MCP server</h2>
 
 <p><code>onedrive mcp</code> starts a read-only <a href="https://modelcontextprotocol.io">Model Context Protocol</a>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,19 @@
+const js = require('@eslint/js')
+const globals = require('globals')
+
+// Flat config: ESLint 9 dropped .eslintrc.* support, and ESLint 10 no longer
+// bundles @eslint/js or globals, so both are declared as devDependencies.
+// Equivalent to the .eslintrc.js this replaces (eslint:recommended, es2018,
+// node globals). bin/onedrive is listed explicitly: flat config only lints a
+// file that some `files` pattern matches, and it has no .js extension.
+module.exports = [
+    js.configs.recommended,
+    {
+        files: ['**/*.js', 'bin/onedrive'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'commonjs',
+            globals: globals.node,
+        },
+    },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
                 "onedrive-cli": "bin/onedrive"
             },
             "devDependencies": {
+                "@eslint/js": "^10.0.1",
                 "eslint": "^10.8.0",
+                "globals": "^17.7.0",
                 "prettier": "^2.8.8"
             },
             "engines": {
@@ -95,6 +97,27 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@eslint/object-schema": {
@@ -1114,6 +1137,19 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "17.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+            "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "eslint": "^10.8.0",
+        "globals": "^17.7.0",
         "prettier": "^2.8.8"
     },
     "prettier": {


### PR DESCRIPTION
Fixes #7, plus the release-blocking lint failure found along the way.

## Shared folders (`d16b1c3`)

A folder shared with you is a **stub** on your drive carrying a `remoteItem` facet — the real item lives on the owner's drive. That is why `stat` worked (the stub is a real item) while `ls` reported no children (the stub genuinely has none), and why nothing below it resolved by path.

`sanitize()` could only build `/drive/root:/…:` paths, so there was no way to address an item on another drive. Three new primitives sit next to it:

| | |
|---|---|
| `itemAddress()` | addresses an item as `/drives/{driveId}/items/{itemId}`, following `remoteItem` to the target on the owner's drive |
| `resolveShared()` | for a path *below* a stub, walks down from the top; the first ancestor with a `remoteItem` is the stub, and the remainder is addressed relative to it |
| `withShared()` | retry wrapper — only fires after a 404, so ordinary paths cost nothing extra |
| `resolveFolder()` | eager resolve for child enumeration, the one case that can't be detected from a failure: listing a stub's children *succeeds* and returns nothing |

Item-relative path addressing off an item id is [documented for exactly this case](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems): *"when working with shared folders, you can use a path-based URL relative to the shared folder's item ID"*.

Applied to `ls`, `find`, `cp -R`, `cat`, `stat`, `rm`, `mv`, `mkdir`, `wget`, `upload` and the MCP `list`/`find`/`read` tools.

Also fixes the second symptom noted in the issue: `is_folder()` and the `ls` columns now read through `remoteItem`, so a shared folder lists as a folder with its owner and child count instead of as an empty file.

Recursive traversal in `find`/`cp -R` now tracks the display path as it descends rather than deriving it from `parentReference.path` — a child on someone else's drive reports a parent path that isn't addressable from our drive.

`chmod`/`ln`/`sendmail` are deliberately left alone: they are owner-side sharing operations, not meaningful on someone else's drive.

## ESLint flat config (`e997228`)

Independent of #7, but it blocks releases, so it is here as its own commit: the [v1.4.0 publish](https://github.com/lionello/onedrive-cli/actions/runs/30743334456/job/91484543176) never reached npm. `package-lock.json` pins ESLint 10.8.0, which since v9 only reads `eslint.config.js`, so `npm ci && npm run lint` exited 2 before `npm publish`.

- `.eslintrc.js` → `eslint.config.js`, with `@eslint/js` and `globals` added as devDeps (ESLint 10 no longer bundles either).
- `bin/onedrive` is listed explicitly in `files`: flat config only lints files a pattern matches, and it has no `.js` extension. Without it eslint reports *"File ignored because no matching configuration was supplied"* and exits 0 — a lint step that lints nothing.
- ESLint 9 also started applying `no-unused-vars` to caught errors, flagging four `catch` blocks that deliberately ignore the error. Unused bindings dropped (optional catch binding; `engines` already requires Node >= 18) rather than weakening the rule.

**To actually ship 1.4.0**, re-running the failed job won't help — it checks out the `v1.4.0` tag, which predates this. Either move the tag after merging (`package.json` still says 1.4.0, so the version-match step passes) or cut 1.4.1.

## Testing

The saved token here was expired, so I could not hit the live API. Instead I built a mock of the classic API with a shared folder on it and ran the CLI against it. Verified working: `ls` of the stub and of folders below it, `cat` at any depth, `stat`, `find` with `-name`/`-type`, `cp -R` (correct contents and local tree), `mkdir`/`rm`/`mv` reaching the owner's drive, and the MCP helpers. Missing paths still fail cleanly in a bounded number of requests. Diffing old vs new output on non-shared paths shows no output changes — only the extra resolve GET and id-based recursion.

`npm run lint` exits 0 against ESLint 10.8.0 and prettier is clean.

**Worth a check against a real shared folder before merging:** `resolveShared()`'s item-relative addressing is the one piece verified only against docs and the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)