### PR TITLE
fix: answer the loopback preflight instead of consuming it as the token

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -732,6 +732,18 @@ function loopbackLogin(readonly) {
     server.on('request', (req, res) => {
         const u = new URL(req.url, 'http://127.0.0.1')
         res.setHeader('Access-Control-Allow-Origin', '*')
+        // Chrome gates requests from a public page to a loopback address behind
+        // a Private Network Access preflight, so the callback page's fetch
+        // arrives as OPTIONS first. Answer it as a preflight and nothing more:
+        // treating it as the delivery would settle the token and let login()
+        // close the listener before the real GET lands, leaving the page unable
+        // to read a 200 and stuck on the manual-copy fallback.
+        if (req.method === 'OPTIONS') {
+            res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+            res.setHeader('Access-Control-Allow-Private-Network', 'true')
+            res.setHeader('Access-Control-Max-Age', '600')
+            return res.writeHead(204).end()
+        }
         if (u.pathname !== '/callback') {
             return res.writeHead(404).end()
         }

--- a/docs/oauthcallbackhandler.html
+++ b/docs/oauthcallbackhandler.html
@@ -520,8 +520,13 @@
                     var state = param(window.location.hash, 'state') || ''
                     var lb = /^([0-9a-f]+)\.(\d+)$/.exec(state)
                     if (lb) {
+                        // 127.0.0.1, not "localhost": the listener binds that
+                        // address (localhost can resolve to ::1 first), and the
+                        // literal is what browsers treat as trustworthy, so
+                        // this http:// request survives on an https:// page
+                        // instead of being blocked or upgraded as mixed content.
                         var target =
-                            'http://localhost:' +
+                            'http://127.0.0.1:' +
                             lb[2] +
                             '/callback?nonce=' +
                             encodeURIComponent(lb[1]) +


### PR DESCRIPTION
The callback page is supposed to detect that the CLI already accepted the token and swap "Almost there." for a done state. It never fired: login succeeded, but the page kept showing the manual-copy fallback.

## Root cause

Chrome gates a request from a public page (`https://www.lunesu.com`) to a loopback address behind a Private Network Access preflight, so the page's `fetch` arrives as `OPTIONS /callback?...` first — same URL, same query string, token and nonce included.

The listener never looked at `req.method`, so the preflight sailed through the nonce check, returned 200, and called `settle(...)`. Reproduced against the unpatched handler:

```
[req] OPTIONS /callback origin=https://www.lunesu.com pna=true acrm=GET
[req] -> 200 ACCEPTED token=FAKETOKEN123
```

Both halves then fail:

- the CLI saves the token and `login()` immediately calls `lb.cancel()`, closing the listener;
- the preflight response carries no `Access-Control-Allow-Private-Network: true`, so Chrome rejects it and never sends the real GET.

`fetch` lands in `.catch()`, `accepted()` never runs, and the page stays on "Almost there." while the terminal is already signed in.

A second, independent problem: the `<img>` fallback cannot work from an HTTPS page. `new Image().src = 'http://localhost:...'` is auto-upgraded to `https://localhost:...` and dies. `localhost` can also resolve to `::1` while the listener binds `127.0.0.1` only.

## Fix

- `bin/onedrive` — handle `OPTIONS` as a preflight and nothing more: 204 with `Access-Control-Allow-Methods`, `Access-Control-Allow-Private-Network: true`, and `Max-Age`. No token settled, listener stays open for the real GET.
- `docs/oauthcallbackhandler.html` — target `127.0.0.1` instead of `localhost`, matching the bind address and using the form browsers treat as trustworthy, so the `http://` request is not blocked or upgraded as mixed content.

## Verification

Against the patched handler: the preflight returns 204 with the PNA header and settles nothing; the follow-up GET settles the token and returns 200 with `ACAO: *` — which is what `resp.ok` needs to fire `accepted()`.

```
--- OPTIONS preflight ---
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Private-Network: true
Access-Control-Max-Age: 600
--- GET ---
[SETTLED] TOK
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
```

## Caveats

- The docs page is served from `www.lunesu.com`, so the HTML half only takes effect once it is published. The CLI change alone does not change what a user sees today.
- The browser half is verified by protocol behavior, not a live click-through — worth one manual `onedrive login` after deploying.
- Chrome 138+ is replacing PNA with a local-network permission prompt. If a user hits that, the request is blocked before it reaches the listener and the CLI gets no token either; the copy fallback remains the right backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)