### PR TITLE
fix: make every commandName() branch runnable when pasted

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -659,28 +659,29 @@ async function cat(args) {
 }
 
 // How the user invoked us, so the landing page can echo a runnable command.
-// Prefer a path relative to the cwd (keeps the folder, e.g. 'bin/onedrive')
-// and fall back to the basename when we live outside the cwd (e.g. an
-// installed 'onedrive' on the PATH).
+// Whatever this returns is pasted into a shell verbatim, so every branch has
+// to be runnable on its own: a short path relative to the cwd when we live
+// there (e.g. 'bin/onedrive'), the bare name when we are on the PATH (e.g. an
+// installed 'onedrive-cli'), and an absolute path otherwise.
 function commandName() {
     const argv1 = process.argv[1] || 'onedrive-cli'
     const rel = Path.relative(process.cwd(), argv1)
     const parts = rel.split(Path.sep)
-    // Running from a directory *above* us yields a long relative path that
-    // reads like a mangled absolute one -- from '/' this file becomes
-    // 'Users/me/dev/onedrive-cli/bin/onedrive', which is neither obviously
-    // runnable nor something to hand to the landing page. Keep at most one
-    // leading folder, and fall back to the basename beyond that.
-    if (
-        !rel ||
-        parts.length > 2 ||
-        rel.startsWith('..') ||
-        Path.isAbsolute(rel)
-    ) {
+    // Keep a relative path only while it stays short and below the cwd. A cwd
+    // *above* us yields a long relative path that reads like a mangled
+    // absolute one -- from '/' this file becomes
+    // 'Users/me/dev/onedrive-cli/bin/onedrive', missing its leading slash.
+    if (rel && parts.length <= 2 && !rel.startsWith('..')) {
+        // A bare name only runs as './name'; with a folder it already does.
+        return parts.length === 1 ? '.' + Path.sep + rel : rel
+    }
+    // On the PATH: the bare name is what the user typed and what reads best.
+    const dirs = (process.env.PATH || '').split(Path.delimiter)
+    if (dirs.includes(Path.dirname(argv1))) {
         return Path.basename(argv1)
     }
-    // A bare name is only runnable as './name'; with a folder it already is.
-    return parts.length === 1 ? '.' + Path.sep + rel : rel
+    // Anywhere else, only an absolute path is guaranteed to run.
+    return Path.resolve(argv1)
 }
 
 function buildLoginUrl(readonly, state) {


### PR DESCRIPTION
`commandName()` feeds the OAuth callback page the command a user pastes into a shell verbatim, so every branch has to be runnable on its own. The bare-basename fallback was not: for a checkout invoked from an unrelated cwd, or any install whose directory is not on the `PATH`, `onedrive` is just not a command.

Now: keep the relative path while it stays short and below the cwd, fall back to the bare name when the script's directory really is on the `PATH`, and use an absolute path everywhere else.

## Before / after

Same function driven over a set of cwd + argv[1] + PATH combinations:

| scenario | before | after |
|---|---|---|
| repo cwd, `bin/onedrive` | `bin/onedrive` | `bin/onedrive` |
| cwd=`/`, deep relative | `onedrive` ❌ | `/Users/…/bin/onedrive` |
| global install, dir on PATH | `onedrive` | `onedrive` |
| sibling checkout, not on PATH | `onedrive` ❌ | `/Users/…/bin/onedrive` |
| cwd == script dir | `./onedrive` | `./onedrive` |

The ❌ rows are the bug: a bare name for something that is not on the `PATH`.

## Checks

- `process.argv[1]` keeps the `PATH` symlink rather than resolving through to the realpath, verified with an npm-global-install-shaped symlink (`bin/od -> ../lib/od.js` run via `PATH`). So the new `PATH`-membership branch does fire for global installs — it is not silently dead.
- The dropped `Path.isAbsolute(rel)` guard is not a regression on Windows: `path.win32.relative('C:\\Users\\me', 'D:\\tools\\onedrive')` returns `D:\tools\onedrive`, which is still an absolute, runnable path whichever branch returns it.

## Known rough edges (not addressed here)

- The `PATH` match is an exact string compare against `Path.dirname(argv[1])`, so a non-canonical entry (`/usr/local/bin/` with a trailing slash, an unexpanded `~`, or a case difference on Windows) misses and falls through to the long absolute path. Runnable, just uglier than needed — normalizing both sides would fix it.
- Paths containing spaces are returned unquoted and break when pasted (`my tools/onedrive` → shell reads `my`). Pre-existing, but the absolute-path branch makes it more reachable, and it contradicts the verbatim-runnable premise. Wants shell quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)