### PR TITLE
fix: ack the token over the channel Chrome actually allows

### DIFF
--- a/bin/onedrive
+++ b/bin/onedrive
@@ -724,6 +724,17 @@ function withTimeout(promise, ms) {
     return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
 }
 
+// A 1x1 transparent GIF, sent as the reply to an accepted token. The callback
+// page has to deliver the token with an <img> GET (Chrome blocks its fetch to a
+// loopback address; a no-cors subresource still gets through), and an image load
+// exposes no status -- only whether the bytes decoded. Answering with real image
+// bytes when, and only when, we accepted the token turns that into the ack the
+// page can observe: a refusal is text, which fails to decode.
+const ACK_GIF = Buffer.from(
+    'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+    'base64'
+)
+
 function loopbackLogin(readonly) {
     const nonce = Crypto.randomBytes(16).toString('hex')
     const server = Http.createServer()
@@ -751,8 +762,11 @@ function loopbackLogin(readonly) {
         if (!token || u.searchParams.get('nonce') !== nonce) {
             return res.writeHead(400).end('bad request')
         }
-        res.writeHead(200, { 'Content-Type': 'text/plain' })
-        res.end('onedrive-cli received the token. You can close this tab.')
+        res.writeHead(200, {
+            'Content-Type': 'image/gif',
+            'Content-Length': ACK_GIF.length,
+        })
+        res.end(ACK_GIF)
         settle(extractToken(token))
     })
     return new Promise((resolve, reject) => {

--- a/docs/oauthcallbackhandler.html
+++ b/docs/oauthcallbackhandler.html
@@ -532,24 +532,32 @@
                             encodeURIComponent(lb[1]) +
                             '&token=' +
                             encodeURIComponent(access_token)
-                        // The listener replies 200 only when it accepted the
-                        // token (nonce matched), and its ACAO:* header lets us
-                        // read that status -- so response.ok is a genuine ack,
-                        // not just "something answered on that port".
+                        // Deliver over both channels the browser might allow,
+                        // and take the ack from whichever one it permitted.
+                        // Chrome gates a public page's access to loopback
+                        // addresses: the CORS fetch is usually blocked outright
+                        // while a no-cors <img> GET still reaches the listener,
+                        // which is how the CLI ends up holding the token with
+                        // this page unable to read any response. Delivery is
+                        // idempotent -- same nonce and token, and the listener
+                        // settles once -- so sending twice is safe.
+                        //
+                        // The listener answers an accepted token with a real
+                        // 1x1 GIF, so a decoded image is a genuine ack; its
+                        // refusal is text, which fails to decode and lands in
+                        // onerror. Only success ever changes the UI, so a
+                        // blocked or refused channel just leaves the copy
+                        // fallback in place.
+                        var img = new Image()
+                        img.onload = accepted
+                        img.src = target
                         fetch(target, { mode: 'cors' })
                             .then(function (resp) {
                                 if (resp.ok) {
                                     accepted()
                                 }
-                                // Non-2xx: the CLI refused the token (stale or
-                                // tampered state) -- keep the copy fallback.
                             })
-                            .catch(function () {
-                                // fetch blocked? fire an <img> GET as a last
-                                // resort. Delivery only: an image load gives no
-                                // readable status, so never claim success here.
-                                new Image().src = target
-                            })
+                            .catch(function () {})
                     }
 
                     // The CLI confirmed it saved the token: say so and retire


### PR DESCRIPTION
Follow-up to #63. That fix was real but incomplete: it stopped the preflight from being mistaken for the delivery, yet the page still could not tell that the CLI had the token, because the confirmation hung on `fetch`'s readable status — and that is the one channel Chrome blocks.

## What actually happens

Chrome 151 gates a public page's access to loopback addresses under **Local Network Access**, the successor to Private Network Access, where `Access-Control-Allow-Private-Network` is no longer honored. So:

1. `fetch('http://127.0.0.1:PORT/callback?…', {mode:'cors'})` is blocked.
2. Its `.catch()` fires `new Image().src = target`.
3. That no-cors image GET **does** reach the listener — the CLI saves the token.
4. An image load exposes no readable status, so `accepted()` never runs and the page keeps telling the user to copy a token the CLI already has.

Reproduced in headless Chrome 151 against the deployed page with a fake token — the page's own console reports the image going out, and the headline stays `Almost there.`:

```
Mixed Content: … requested an insecure element 'http://127.0.0.1:43117/callback?nonce=…&token=…'.
This request was not upgraded to HTTPS because its URL's host is an IP address.
```
```
=== PAGE HEADLINE ===
<h1>Almost there.</h1>
```

## Fix

Stop trying to read a response; make the delivery itself observable.

- `bin/onedrive` — reply to an accepted token with a real 1x1 GIF (`image/gif`) instead of plain text.
- `docs/oauthcallbackhandler.html` — deliver via `<img>` as well as `fetch`, and hang `accepted()` on `img.onload`.

A refusal stays `400 bad request` as text, which fails to decode and lands in `onerror`, so a stale or tampered `state` cannot fake success. Both channels are attempted — delivery is idempotent (same nonce and token, and the listener settles once) — and only a success signal ever changes the UI, so a blocked channel just leaves the copy fallback in place.

## Verification

Listener responses:

| request | response |
|---|---|
| GET, nonce matches | `200 image/gif`, `Content-Length: 34`, `GIF image data, version 89a, 1 x 1` |
| GET, nonce wrong | `400` text, nothing settled |
| OPTIONS preflight | `204` |

End to end in real Chrome 151 (`<img>`-only page, so the ack path is what is under test):

```
=== page result ===
ACK: onload fired
=== listener log ===
[listener] GET /callback?nonce=deabeef…&token=THE_T dest=image
settled token: THE_TOKEN
```

Wrong nonce, same harness: `NO ACK: onerror fired`, `settled token: NONE`.

## Limits

- Headless Chrome blocks the image too (no permission prompt to grant), so the public-origin → loopback hop itself could not be exercised headlessly. But that hop is exactly what already delivers the token today, so wherever delivery works the ack now works with it. Worth one real `onedrive login` to confirm.
- Forwarding from a hosted page to a loopback port depends on browsers continuing to permit *some* cross-origin request to a local address, which they keep tightening. Switching `redirect_uri` to `http://127.0.0.1:<port>` would sidestep that entirely, but it is **not an option here**: a dev container without a port mapping is unreachable from the host browser, so the redirect would simply fail where the hosted page still loads and degrades to the copy command. The hosted page plus best-effort loopback forwarding stays the design; if a future browser closes the image channel as well, the copy fallback is what remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)